### PR TITLE
Fix errno 22 errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ test:
 # Drops you into a shell in the development container and mounts the source code
 # You can edit to source on your host, then run go commans (e.g., `go test ./...`) inside the container
 dev:
-	sh -c "if ! docker image ls | grep '$(DEV_IMAGE)'; then echo 'building dev image'; docker build -f $(DEV_DOCKERFILE) -t $(DEV_IMAGE) .; fi"
+	sh -c "if ! docker image ls | grep '$(DEV_IMAGE)' | cut -d ':' -f1; then echo 'building dev image'; docker build -f $(DEV_DOCKERFILE) -t $(DEV_IMAGE) .; fi"
 	docker run -it \
 		       --rm \
 			   -v $(PROJECT_DIR):/go/src/github.com/dominicbreuker/pspy \
@@ -38,7 +38,7 @@ example:
 # builds one set of static binaries that should work on any system without dependencies, but are huge
 # builds another set of binaries that are as small as possible, but may not work 
 build:
-	sh -c "if ! docker image ls | grep '$(BUILD_IMAGE)'; then echo 'building build image'; docker build -f $(BUILD_DOCKERFILE) -t $(BUILD_IMAGE) .; fi"
+	sh -c "if ! docker image ls | grep '$(BUILD_IMAGE)' | cut -d ':' -f1; then echo 'building build image'; docker build -f $(BUILD_DOCKERFILE) -t $(BUILD_IMAGE) .; fi"
 
 	mkdir -p $(PROJECT_DIR)/bin
 	docker run -it \

--- a/internal/fswatcher/inotify/inotify.go
+++ b/internal/fswatcher/inotify/inotify.go
@@ -17,7 +17,8 @@ const maximumWatchersFile = "/proc/sys/fs/inotify/max_user_watches"
 // set to -1 if the number cannot be determined
 var MaxWatchers int = -1
 
-const EventSize int = unix.SizeofInotifyEvent
+// sizeof(struct inotify_event) + NAME_MAX + 1
+const EventSize int = unix.SizeofInotifyEvent + 255 + 1
 
 func init() {
 	mw, err := getMaxWatchers()
@@ -71,7 +72,7 @@ func (i *Inotify) Watch(dir string) error {
 
 func (i *Inotify) Read(buf []byte) (int, error) {
 	n, errno := unix.Read(i.FD, buf)
-	if n < 0 {
+	if n < 1 {
 		return n, fmt.Errorf("reading from inotify fd %d: errno: %d", i.FD, errno)
 	}
 	return n, nil


### PR DESCRIPTION
In issue #3 many people complain about errno 22 on reading from inotify. Cannot reproduce but my theory is that Linux does not like the small buffer it gets. This makes it bigger as described here: http://man7.org/linux/man-pages/man7/inotify.7.html