### PR TITLE
Skip event processing while draining

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,30 +47,30 @@ build:
 	docker run -it \
 		       --rm \
 		       -v $(PROJECT_DIR):/go/src/github.com/dominicbreuker/pspy \
-			   -w "/go/src/github.com/dominicbreuker" \
+			   -w "/go/src/github.com/dominicbreuker/pspy" \
 			   --env CGO_ENABLED=0 \
 			   --env GOOS=linux \
 			  --env GOARCH=386 \
-	           $(BUILD_IMAGE) /bin/sh -c "go build -a -ldflags '-s -w -X main.version=${VERSION} -X main.commit=${BUILD_SHA} -extldflags \"-static\"' -o pspy/bin/pspy32 pspy/main.go"
+	           $(BUILD_IMAGE) /bin/sh -c "go build -a -ldflags '-s -w -X main.version=${VERSION} -X main.commit=${BUILD_SHA} -extldflags \"-static\"' -o bin/pspy32 main.go"
 	docker run -it \
 		       --rm \
 		       -v $(PROJECT_DIR):/go/src/github.com/dominicbreuker/pspy \
-			   -w "/go/src/github.com/dominicbreuker" \
+			   -w "/go/src/github.com/dominicbreuker/pspy" \
 			   --env CGO_ENABLED=0 \
 			   --env GOOS=linux \
 			   --env GOARCH=amd64 \
-	           $(BUILD_IMAGE) /bin/sh -c "go build -a -ldflags '-s -w -X main.version=${VERSION} -X main.commit=${BUILD_SHA} -extldflags \"-static\"' -o pspy/bin/pspy64 pspy/main.go"
+	           $(BUILD_IMAGE) /bin/sh -c "go build -a -ldflags '-s -w -X main.version=${VERSION} -X main.commit=${BUILD_SHA} -extldflags \"-static\"' -o bin/pspy64 main.go"
 	docker run -it \
 		       --rm \
 		       -v $(PROJECT_DIR):/go/src/github.com/dominicbreuker/pspy \
-			   -w "/go/src/github.com/dominicbreuker" \
+			   -w "/go/src/github.com/dominicbreuker/pspy" \
 			   --env GOOS=linux \
 			   --env GOARCH=386 \
-	           $(BUILD_IMAGE) /bin/sh -c "go build -ldflags '-w -s -X main.version=${VERSION} -X main.commit=${BUILD_SHA}' -o pspy/bin/pspy32s pspy/main.go && upx pspy/bin/pspy32s"
+	           $(BUILD_IMAGE) /bin/sh -c "go build -ldflags '-w -s -X main.version=${VERSION} -X main.commit=${BUILD_SHA}' -o bin/pspy32s main.go && upx bin/pspy32s"
 	docker run -it \
 		       --rm \
 		       -v $(PROJECT_DIR):/go/src/github.com/dominicbreuker/pspy \
-			   -w "/go/src/github.com/dominicbreuker" \
+			   -w "/go/src/github.com/dominicbreuker/pspy" \
 			   --env GOOS=linux \
 			   --env GOARCH=amd64 \
-	           $(BUILD_IMAGE) /bin/sh -c "go build -ldflags '-w -s -X main.version=${VERSION} -X main.commit=${BUILD_SHA}' -o pspy/bin/pspy64s pspy/main.go && upx pspy/bin/pspy64s"
+	           $(BUILD_IMAGE) /bin/sh -c "go build -ldflags '-w -s -X main.version=${VERSION} -X main.commit=${BUILD_SHA}' -o bin/pspy64s main.go && upx bin/pspy64s"

--- a/docker/Dockerfile.build
+++ b/docker/Dockerfile.build
@@ -1,3 +1,3 @@
-FROM golang:1.18-bullseye
+FROM golang:1.19-bullseye
 
 RUN apt-get update && apt-get install -y upx && rm -rf /var/lib/apt/lists/*

--- a/docker/Dockerfile.development
+++ b/docker/Dockerfile.development
@@ -1,4 +1,4 @@
-FROM golang:1.18-bullseye
+FROM golang:1.19-bullseye
 
 RUN apt-get update && apt-get -y install cron python3 sudo procps
 

--- a/docker/Dockerfile.testing
+++ b/docker/Dockerfile.testing
@@ -1,4 +1,4 @@
-FROM golang:1.18-bullseye
+FROM golang:1.19-bullseye
 
 RUN apt-get update && apt-get -y install cron python3 sudo procps
 
@@ -8,7 +8,8 @@ RUN apt-get update && apt-get -y install cron python3 sudo procps
 COPY main.go /go/src/github.com/dominicbreuker/pspy/main.go
 COPY cmd /go/src/github.com/dominicbreuker/pspy/cmd
 COPY internal /go/src/github.com/dominicbreuker/pspy/internal
-COPY vendor /go/src/github.com/dominicbreuker/pspy/vendor
+COPY go.mod /go/src/github.com/dominicbreuker/pspy/go.mod
+COPY go.sum /go/src/github.com/dominicbreuker/pspy/go.sum
 COPY .git /go/src/github.com/dominicbreuker/pspy/.git
 
 # run tests

--- a/internal/pspy/pspy_test.go
+++ b/internal/pspy/pspy_test.go
@@ -68,8 +68,6 @@ func TestStartFSW(t *testing.T) {
 	sigCh := make(chan os.Signal)
 
 	go func() {
-		fsw.runTriggerCh <- struct{}{} // trigger sent while draining
-		fsw.runEventCh <- "event sent while draining"
 		fsw.runErrCh <- errors.New("error sent while draining")
 		<-time.After(drainFor) // ensure draining is over
 		fsw.runTriggerCh <- struct{}{}
@@ -292,6 +290,10 @@ func (fsw *mockFSWatcher) Init(rdirs, dirs []string) (chan error, chan struct{})
 
 func (fsw *mockFSWatcher) Run() (chan struct{}, chan string, chan error) {
 	return fsw.runTriggerCh, fsw.runEventCh, fsw.runErrCh
+}
+
+func (fsw *mockFSWatcher) Enable() {
+	return
 }
 
 // PSScanner


### PR DESCRIPTION
Potential fix for #19

pspy ignores inotify events on startup fort 1 sec because it creates plenty of them itself while placing watchers. Originally this was implemented by skipping it's internal trigger and event channels. On one of my systems the draining period regularly exceeded 1 sec and it seemed that this was due to too many messages in the channel. 

This PR skips creation of messages in Golang channels during draining. For me it fixed the issues. Let's see what others say :) 